### PR TITLE
Add 4 new Python visualization charts + improve existing scatter plots

### DIFF
--- a/tutorials/analysis/.gitignore
+++ b/tutorials/analysis/.gitignore
@@ -1,0 +1,6 @@
+# Python
+scripts/__pycache__/
+*.pyc
+
+# Generated output
+output/

--- a/tutorials/analysis/scripts/README.md
+++ b/tutorials/analysis/scripts/README.md
@@ -19,3 +19,16 @@ Files include:
 - Chart generation - This section will grow. Each script will scan the parameters.py file and determine which charts are available for each contest and prompt the user to select an available one.
   - [scatter_plot.py](scatter_plot.py) - generates scatter plot chart for candidate vote share by precinct vote total
   - [turnout_scatter_plot.py](turnout_scatter_plot.py) - generates scatter plot for candidate vote share by turnout percentage
+  - [turnout_histogram.py](turnout_histogram.py) - generates overlapping turnout histograms with KDE curves and skew values for each candidate
+  - [vote_share_histogram.py](vote_share_histogram.py) - generates histogram of precinct counts by candidate vote share percentage
+  - [turnout_heatmap.py](turnout_heatmap.py) - generates 2D kernel density heatmap of candidate vote share by turnout (matches DensityHeatmapByTurnout dashboard component)
+  - [turnout_bar_chart.py](turnout_bar_chart.py) - generates grouped bar chart of candidate votes sorted by turnout percentage
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+python scatter_plot.py
+```
+
+Each script will prompt you to select from the available races configured in `parameters.py`. Output PNGs are saved to `../output/`.

--- a/tutorials/analysis/scripts/parameters.py
+++ b/tutorials/analysis/scripts/parameters.py
@@ -13,14 +13,34 @@ params = {
             "candidate_b_color": default_candidate_b_color,
             "scatter_plot": {
                 "title": "Pennsylvania - Allegheny - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Precinct Vote Total",
-                "x_axis_label": "Total Votes",
+                "x_axis_label": "Number of Votes by Precinct",
                 "y_axis_label": "Candidate Vote Share (%)",
             },
             "turnout_scatter_plot": {
                 "title": "Pennsylvania - Allegheny - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout Percentage",
-                "x_axis_label": "Voter Turnout Percentage",
+                "x_axis_label": "Voter Turnout (%)",
                 "y_axis_label": "Candidate Vote Share (%)",
-            }
+            },
+            "turnout_histogram": {
+                "title": "Pennsylvania - Allegheny - 2024 - Presidential - Election Day Votes\nVote Distribution by Turnout",
+                "x_axis_label": "Voter Turnout (%)",
+                "y_axis_label": "Number of Votes",
+            },
+            "vote_share_histogram": {
+                "title": "Pennsylvania - Allegheny - 2024 - Presidential - Election Day Votes\nPrecinct Count by Vote Share",
+                "x_axis_label": "Candidate Vote Share (%)",
+                "y_axis_label": "Number of Precincts",
+            },
+            "turnout_heatmap": {
+                "title": "Pennsylvania - Allegheny - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout (Density)",
+                "x_axis_label": "Voter Turnout (%)",
+                "y_axis_label": "Candidate Vote Share (%)",
+            },
+            "turnout_bar_chart": {
+                "title": "Pennsylvania - Allegheny - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout",
+                "x_axis_label": "Voter Turnout (%)",
+                "y_axis_label": "Candidate Vote Share (%)",
+            },
         }
     },
     "2024_general_north_carolina_wake": {
@@ -34,14 +54,34 @@ params = {
             "candidate_b_color": default_candidate_b_color,
             "scatter_plot": {
                 "title": "North Carolina - Wake - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Precinct Vote Total",
-                "x_axis_label": "Total Votes",
+                "x_axis_label": "Number of Votes by Precinct",
                 "y_axis_label": "Candidate Vote Share (%)",
             },
             "turnout_scatter_plot": {
                 "title": "North Carolina - Wake - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout Percentage",
-                "x_axis_label": "Voter Turnout Percentage",
+                "x_axis_label": "Voter Turnout (%)",
                 "y_axis_label": "Candidate Vote Share (%)",
-            }
+            },
+            "turnout_histogram": {
+                "title": "North Carolina - Wake - 2024 - Presidential - Election Day Votes\nVote Distribution by Turnout",
+                "x_axis_label": "Voter Turnout (%)",
+                "y_axis_label": "Number of Votes",
+            },
+            "vote_share_histogram": {
+                "title": "North Carolina - Wake - 2024 - Presidential - Election Day Votes\nPrecinct Count by Vote Share",
+                "x_axis_label": "Candidate Vote Share (%)",
+                "y_axis_label": "Number of Precincts",
+            },
+            "turnout_heatmap": {
+                "title": "North Carolina - Wake - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout (Density)",
+                "x_axis_label": "Voter Turnout (%)",
+                "y_axis_label": "Candidate Vote Share (%)",
+            },
+            "turnout_bar_chart": {
+                "title": "North Carolina - Wake - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout",
+                "x_axis_label": "Voter Turnout (%)",
+                "y_axis_label": "Candidate Vote Share (%)",
+            },
         },
         "attorney_general": {
             "file": "../files/2024_G_NC_Attorney_General.xlsx",
@@ -53,14 +93,34 @@ params = {
             "candidate_b_color": default_candidate_b_color,
             "scatter_plot": {
                 "title": "North Carolina - Wake - 2024 - Attorney General - Election Day Votes\nCandidate Vote Share by Precinct Vote Total",
-                "x_axis_label": "Total Votes",
+                "x_axis_label": "Number of Votes by Precinct",
                 "y_axis_label": "Candidate Vote Share (%)",
             },
             "turnout_scatter_plot": {
                 "title": "North Carolina - Wake - 2024 - Attorney General - Election Day Votes\nCandidate Vote Share by Turnout Percentage",
-                "x_axis_label": "Voter Turnout Percentage",
+                "x_axis_label": "Voter Turnout (%)",
                 "y_axis_label": "Candidate Vote Share (%)",
-            }
+            },
+            "turnout_histogram": {
+                "title": "North Carolina - Wake - 2024 - Attorney General - Election Day Votes\nVote Distribution by Turnout",
+                "x_axis_label": "Voter Turnout (%)",
+                "y_axis_label": "Number of Votes",
+            },
+            "vote_share_histogram": {
+                "title": "North Carolina - Wake - 2024 - Attorney General - Election Day Votes\nPrecinct Count by Vote Share",
+                "x_axis_label": "Candidate Vote Share (%)",
+                "y_axis_label": "Number of Precincts",
+            },
+            "turnout_heatmap": {
+                "title": "North Carolina - Wake - 2024 - Attorney General - Election Day Votes\nCandidate Vote Share by Turnout (Density)",
+                "x_axis_label": "Voter Turnout (%)",
+                "y_axis_label": "Candidate Vote Share (%)",
+            },
+            "turnout_bar_chart": {
+                "title": "North Carolina - Wake - 2024 - Attorney General - Election Day Votes\nCandidate Vote Share by Turnout",
+                "x_axis_label": "Voter Turnout (%)",
+                "y_axis_label": "Candidate Vote Share (%)",
+            },
         }
     }
 }

--- a/tutorials/analysis/scripts/parameters.py
+++ b/tutorials/analysis/scripts/parameters.py
@@ -15,6 +15,7 @@ params = {
                 "title": "Pennsylvania - Allegheny - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Precinct Vote Total",
                 "x_axis_label": "Number of Votes by Precinct",
                 "y_axis_label": "Candidate Vote Share (%)",
+                "trend_min_points": 5,
             },
             "turnout_scatter_plot": {
                 "title": "Pennsylvania - Allegheny - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout Percentage",
@@ -35,11 +36,13 @@ params = {
                 "title": "Pennsylvania - Allegheny - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout (Density)",
                 "x_axis_label": "Voter Turnout (%)",
                 "y_axis_label": "Candidate Vote Share (%)",
+                "candidate": "a",  # "a" or "b" — which candidate's density to show
             },
             "turnout_bar_chart": {
                 "title": "Pennsylvania - Allegheny - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout",
                 "x_axis_label": "Voter Turnout (%)",
                 "y_axis_label": "Candidate Vote Share (%)",
+                "bin_pct": 4,  # turnout bin size in percentage points
             },
         }
     },
@@ -56,6 +59,7 @@ params = {
                 "title": "North Carolina - Wake - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Precinct Vote Total",
                 "x_axis_label": "Number of Votes by Precinct",
                 "y_axis_label": "Candidate Vote Share (%)",
+                "trend_min_points": 15,
             },
             "turnout_scatter_plot": {
                 "title": "North Carolina - Wake - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout Percentage",
@@ -76,11 +80,13 @@ params = {
                 "title": "North Carolina - Wake - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout (Density)",
                 "x_axis_label": "Voter Turnout (%)",
                 "y_axis_label": "Candidate Vote Share (%)",
+                "candidate": "a",  # "a" or "b" — which candidate's density to show
             },
             "turnout_bar_chart": {
                 "title": "North Carolina - Wake - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout",
                 "x_axis_label": "Voter Turnout (%)",
                 "y_axis_label": "Candidate Vote Share (%)",
+                "bin_pct": 4,  # turnout bin size in percentage points
             },
         },
         "attorney_general": {
@@ -95,6 +101,7 @@ params = {
                 "title": "North Carolina - Wake - 2024 - Attorney General - Election Day Votes\nCandidate Vote Share by Precinct Vote Total",
                 "x_axis_label": "Number of Votes by Precinct",
                 "y_axis_label": "Candidate Vote Share (%)",
+                "trend_min_points": 5,
             },
             "turnout_scatter_plot": {
                 "title": "North Carolina - Wake - 2024 - Attorney General - Election Day Votes\nCandidate Vote Share by Turnout Percentage",
@@ -115,11 +122,13 @@ params = {
                 "title": "North Carolina - Wake - 2024 - Attorney General - Election Day Votes\nCandidate Vote Share by Turnout (Density)",
                 "x_axis_label": "Voter Turnout (%)",
                 "y_axis_label": "Candidate Vote Share (%)",
+                "candidate": "a",  # "a" or "b" — which candidate's density to show
             },
             "turnout_bar_chart": {
                 "title": "North Carolina - Wake - 2024 - Attorney General - Election Day Votes\nCandidate Vote Share by Turnout",
                 "x_axis_label": "Voter Turnout (%)",
                 "y_axis_label": "Candidate Vote Share (%)",
+                "bin_pct": 4,  # turnout bin size in percentage points
             },
         }
     }

--- a/tutorials/analysis/scripts/parameters.py
+++ b/tutorials/analysis/scripts/parameters.py
@@ -42,7 +42,7 @@ params = {
                 "title": "Pennsylvania - Allegheny - 2024 - Presidential - Election Day Votes\nCandidate Vote Share by Turnout",
                 "x_axis_label": "Voter Turnout (%)",
                 "y_axis_label": "Candidate Vote Share (%)",
-                "bin_pct": 4,  # turnout bin size in percentage points
+                "bin_pct": 1,  # turnout bin size in percentage points (matches dashboard)
             },
         }
     },

--- a/tutorials/analysis/scripts/requirements.txt
+++ b/tutorials/analysis/scripts/requirements.txt
@@ -1,3 +1,5 @@
 pandas>=1.5.0
 matplotlib>=3.5.0
 openpyxl>=3.0.0
+numpy>=1.21.0
+scipy>=1.7.0

--- a/tutorials/analysis/scripts/scatter_plot.py
+++ b/tutorials/analysis/scripts/scatter_plot.py
@@ -1,52 +1,147 @@
+"""
+Scatter plot: Candidate Vote Share (%) vs Number of Votes by Precinct.
+
+Visual style matches the React/D3 ScatterPlot.tsx component:
+  - Hollow circles (white fill, colored stroke)
+  - Stroke colour gradient light→dark based on total votes
+  - Dot size scales 0.4× – 2.0× of base radius (3 pt) with total votes
+  - Segmented trend lines (segment every 200 votes if max>1000, else 100;
+    min 5 points per segment)
+  - Legend at top with square colour swatches
+  - Clean white background
+"""
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import matplotlib.patches as mpatches
+from matplotlib.ticker import PercentFormatter
+import numpy as np
+
 import utils
 import parameters
-import matplotlib
-matplotlib.use("MacOSX")
-import matplotlib.pyplot as plt
-from matplotlib.ticker import PercentFormatter
 
 
+# ── colour helpers ──────────────────────────────────────────────────────
+def _lerp_color(c1_hex: str, c2_hex: str, t: float) -> str:
+    """Linearly interpolate between two hex colours; t in [0, 1]."""
+    c1 = np.array(mcolors.hex2color(c1_hex))
+    c2 = np.array(mcolors.hex2color(c2_hex))
+    return mcolors.rgb2hex(c1 + (c2 - c1) * np.clip(t, 0, 1))
+
+
+def _build_color_array(total_votes: np.ndarray, light: str, dark: str) -> list:
+    """Return a list of hex stroke colours based on normalised total_votes."""
+    mn, mx = total_votes.min(), total_votes.max()
+    if mx == mn:
+        return [dark] * len(total_votes)
+    t = (total_votes - mn) / (mx - mn)
+    return [_lerp_color(light, dark, ti) for ti in t]
+
+
+def _build_sizes(total_votes: np.ndarray, base: float = 3.0) -> np.ndarray:
+    """Return matplotlib marker *area* array (scatter 's' param is area)."""
+    mn, mx = total_votes.min(), total_votes.max()
+    if mx == mn:
+        factor = np.ones_like(total_votes) * 1.2
+    else:
+        factor = 0.4 + (total_votes - mn) / (mx - mn) * (2.0 - 0.4)
+    radii = base * factor
+    return np.pi * radii ** 2          # scatter uses area
+
+
+# ── segmented trend lines ──────────────────────────────────────────────
+def _segmented_trend(x: np.ndarray, y: np.ndarray, max_votes: float):
+    """Return arrays of (seg_x, seg_y) averages for each segment."""
+    seg_size = 200 if max_votes > 1000 else 100
+    max_boundary = int(np.ceil(max_votes / seg_size)) * seg_size
+
+    seg_xs, seg_ys = [], []
+    for lo in range(0, max_boundary, seg_size):
+        hi = lo + seg_size
+        mask = (x >= lo) & (x < hi)
+        if mask.sum() >= 5:
+            seg_xs.append(float(x[mask].mean()))
+            seg_ys.append(float(y[mask].mean()))
+    return np.array(seg_xs), np.array(seg_ys)
+
+
+# ── main chart ─────────────────────────────────────────────────────────
 def create_scatter_plot(df,
                         candidate_a_column,
                         candidate_b_column,
                         total_column,
                         title,
-                        x_axis_label,
-                        y_axis_label,
-                        candidate_a_color,
-                        candidate_b_color,
-                        min_dot_size=4,
-                        max_dot_size=40):
+                        candidate_a_color_unused,
+                        candidate_b_color_unused):
+
+    total = df[total_column].values.astype(float)
+    share_a = df[f'{candidate_a_column}_share'].values.astype(float)
+    share_b = df[f'{candidate_b_column}_share'].values.astype(float)
+
+    # Colour gradients matching React: red (A) and blue (B)
+    colors_a = _build_color_array(total, "#ffa6a9", "#63000c")   # red light→dark
+    colors_b = _build_color_array(total, "#80b3ff", "#002d75")   # blue light→dark
+    sizes = _build_sizes(total, base=3.0)
+
+    # ── figure ──────────────────────────────────────────────────────────
+    fig, ax = plt.subplots(figsize=(12, 7), facecolor="white")
+    ax.set_facecolor("white")
+
+    # Hollow circles: white fill, coloured stroke
+    ax.scatter(total, share_b, s=sizes,
+               facecolors="white", edgecolors=colors_b, linewidths=1.5,
+               zorder=2)
+    ax.scatter(total, share_a, s=sizes,
+               facecolors="white", edgecolors=colors_a, linewidths=1.5,
+               zorder=2)
+
+    # ── trend lines ─────────────────────────────────────────────────────
+    max_votes = total.max()
+    tx_b, ty_b = _segmented_trend(total, share_b, max_votes)
+    tx_a, ty_a = _segmented_trend(total, share_a, max_votes)
+
+    if len(tx_b) >= 2:
+        ax.plot(tx_b, ty_b, color="#1e40af", linewidth=5, solid_capstyle="round", solid_joinstyle="round", zorder=3)
+        ax.plot(tx_b, ty_b, 'o', color="#1e40af", markersize=7, alpha=0.5, zorder=4)
+    if len(tx_a) >= 2:
+        ax.plot(tx_a, ty_a, color="#9f1239", linewidth=5, solid_capstyle="round", solid_joinstyle="round", zorder=3)
+        ax.plot(tx_a, ty_a, 'o', color="#9f1239", markersize=7, alpha=0.5, zorder=4)
+
+    # ── axes ────────────────────────────────────────────────────────────
+    ax.set_ylim(0, 1)
+    ax.yaxis.set_major_formatter(PercentFormatter(1))
+    ax.set_xlabel("Number of Votes by Precinct", fontsize=14, fontweight="bold")
+    ax.set_ylabel("Candidate Vote Share (%)", fontsize=14, fontweight="bold")
+    ax.set_title(title, fontsize=14, fontweight="bold", pad=12)
+
+    ax.tick_params(labelsize=12)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    # ── legend (square swatches at top) ─────────────────────────────────
+    swatch_b = mpatches.Patch(facecolor="#4287f5", edgecolor="#333",
+                              label=candidate_b_column)
+    swatch_a = mpatches.Patch(facecolor="#e63946", edgecolor="#333",
+                              label=candidate_a_column)
+    trend_b = plt.Line2D([], [], color="#1e40af", linewidth=5,
+                         marker='o', markersize=7, alpha=0.5,
+                         label=f"{candidate_b_column} Trend")
+    trend_a = plt.Line2D([], [], color="#9f1239", linewidth=5,
+                         marker='o', markersize=7, alpha=0.5,
+                         label=f"{candidate_a_column} Trend")
+    ax.legend(handles=[swatch_b, swatch_a, trend_b, trend_a],
+              loc="upper center", bbox_to_anchor=(0.5, 1.0),
+              ncol=4, frameon=False, fontsize=11,
+              handlelength=1.5, handleheight=1.2)
+
+    fig.tight_layout()
+    return fig
 
 
-    plt.scatter(df[total_column],
-                df[f'{candidate_a_column}_share'],
-                alpha=0.3,
-                s=utils.get_dot_size(min_dot_size, max_dot_size, df[candidate_a_column]),
-                color=candidate_a_color,
-                edgecolors=candidate_a_color,
-                label=candidate_a_column)
-
-    plt.scatter(df[total_column],
-                df[f'{candidate_b_column}_share'],
-                s=utils.get_dot_size(min_dot_size, max_dot_size, df[candidate_b_column]),
-                alpha=0.3,
-                edgecolors=candidate_b_color,
-                color=candidate_b_color,
-                label=candidate_b_column)
-
-    # add labels and title
-    plt.xlabel(x_axis_label)
-    plt.ylabel(y_axis_label)
-    plt.title(title)
-
-    plt.gca().yaxis.set_major_formatter(PercentFormatter(1))
-
-
-# show it
-    plt.show()
-
-
+# ── entry point ────────────────────────────────────────────────────────
 if __name__ == "__main__":
     race = utils.choose_race_for_chart(parameters.params, chart_key="scatter_plot")
     if not race:
@@ -56,22 +151,26 @@ if __name__ == "__main__":
     print(f"\nUsing: {election_key} / {race_key}\n")
 
     df = utils.load_data_frame(race_cfg["file"])
-
     clean_df = utils.get_voter_stats(
         df,
         race_cfg["registration_column"],
         race_cfg["candidate_a_column"],
         race_cfg["candidate_b_column"],
-        race_cfg["total_column"]
+        race_cfg["total_column"],
     )
 
-    create_scatter_plot(
+    fig = create_scatter_plot(
         clean_df,
         race_cfg["candidate_a_column"],
         race_cfg["candidate_b_column"],
         race_cfg["total_column"],
         race_cfg["scatter_plot"]["title"],
-        race_cfg["scatter_plot"]["x_axis_label"],
-        race_cfg["scatter_plot"]["y_axis_label"],
         race_cfg["candidate_a_color"],
-        race_cfg["candidate_b_color"])
+        race_cfg["candidate_b_color"],
+    )
+
+    out_dir = utils.ensure_output_dir()
+    out_path = out_dir / f"{election_key}_{race_key}_scatter_plot.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved → {out_path}")

--- a/tutorials/analysis/scripts/scatter_plot.py
+++ b/tutorials/analysis/scripts/scatter_plot.py
@@ -53,8 +53,16 @@ def _build_sizes(total_votes: np.ndarray, base: float = 3.0) -> np.ndarray:
 
 
 # ── segmented trend lines ──────────────────────────────────────────────
-def _segmented_trend(x: np.ndarray, y: np.ndarray, max_votes: float):
-    """Return arrays of (seg_x, seg_y) averages for each segment."""
+def _segmented_trend(x: np.ndarray, y: np.ndarray, max_votes: float,
+                     min_points: int = 5):
+    """Return arrays of (seg_x, seg_y) averages for each segment.
+
+    Parameters
+    ----------
+    min_points : int
+        Minimum data points required in a segment to include it.
+        Configurable via parameters.py ``scatter_plot.trend_min_points``.
+    """
     seg_size = 200 if max_votes > 1000 else 100
     max_boundary = int(np.ceil(max_votes / seg_size)) * seg_size
 
@@ -62,7 +70,7 @@ def _segmented_trend(x: np.ndarray, y: np.ndarray, max_votes: float):
     for lo in range(0, max_boundary, seg_size):
         hi = lo + seg_size
         mask = (x >= lo) & (x < hi)
-        if mask.sum() >= 5:
+        if mask.sum() >= min_points:
             seg_xs.append(float(x[mask].mean()))
             seg_ys.append(float(y[mask].mean()))
     return np.array(seg_xs), np.array(seg_ys)
@@ -75,7 +83,8 @@ def create_scatter_plot(df,
                         total_column,
                         title,
                         candidate_a_color_unused,
-                        candidate_b_color_unused):
+                        candidate_b_color_unused,
+                        trend_min_points: int = 5):
 
     total = df[total_column].values.astype(float)
     share_a = df[f'{candidate_a_column}_share'].values.astype(float)
@@ -100,8 +109,8 @@ def create_scatter_plot(df,
 
     # ── trend lines ─────────────────────────────────────────────────────
     max_votes = total.max()
-    tx_b, ty_b = _segmented_trend(total, share_b, max_votes)
-    tx_a, ty_a = _segmented_trend(total, share_a, max_votes)
+    tx_b, ty_b = _segmented_trend(total, share_b, max_votes, min_points=trend_min_points)
+    tx_a, ty_a = _segmented_trend(total, share_a, max_votes, min_points=trend_min_points)
 
     if len(tx_b) >= 2:
         ax.plot(tx_b, ty_b, color="#1e40af", linewidth=5, solid_capstyle="round", solid_joinstyle="round", zorder=3)
@@ -159,14 +168,16 @@ if __name__ == "__main__":
         race_cfg["total_column"],
     )
 
+    chart_cfg = race_cfg["scatter_plot"]
     fig = create_scatter_plot(
         clean_df,
         race_cfg["candidate_a_column"],
         race_cfg["candidate_b_column"],
         race_cfg["total_column"],
-        race_cfg["scatter_plot"]["title"],
+        chart_cfg["title"],
         race_cfg["candidate_a_color"],
         race_cfg["candidate_b_color"],
+        trend_min_points=chart_cfg.get("trend_min_points", 5),
     )
 
     out_dir = utils.ensure_output_dir()

--- a/tutorials/analysis/scripts/turnout_bar_chart.py
+++ b/tutorials/analysis/scripts/turnout_bar_chart.py
@@ -79,49 +79,23 @@ def create_turnout_bar_chart(df,
     increment = bin_pct / 100.0
     n_bins = int(np.ceil(1.0 / increment))
 
-    # Find the range of bins that have data, include all bins in that range
-    # (including empty ones) for even spacing
-    first_bin = None
-    last_bin = None
-    for i in range(n_bins):
-        lo = i * increment
-        hi = min((i + 1) * increment, 1.0)
-        mask = (turnout >= lo) & (turnout < hi)
-        if mask.sum() > 0:
-            if first_bin is None:
-                first_bin = i
-            last_bin = i
-
-    if first_bin is None:
-        first_bin, last_bin = 0, 0
-
-    # Trim trailing bins from the right where count < min_precincts
-    # (keeps all bins from first data to last meaningful data)
-    trimmed_last = first_bin
-    for i in range(first_bin, last_bin + 1):
-        lo = i * increment
-        hi = min((i + 1) * increment, 1.0)
-        mask = (turnout >= lo) & (turnout < hi)
-        if mask.sum() >= min_precincts:
-            trimmed_last = i
-
+    # Collect all bins that have data (skip empty bins, matching React
+    # ``rangesWithData.filter(d => d.count > 0)`` behaviour)
     bin_labels = []
     avg_a = []
     avg_b = []
     counts = []
 
-    for i in range(first_bin, trimmed_last + 1):
+    for i in range(n_bins):
         lo = i * increment
         hi = min((i + 1) * increment, 1.0)
         mask = (turnout >= lo) & (turnout < hi)
         cnt = mask.sum()
-        bin_labels.append(f"{int(round(lo * 100))}%")
         if cnt == 0:
-            avg_a.append(0.0)
-            avg_b.append(0.0)
-        else:
-            avg_a.append(float(share_a[mask].mean()))
-            avg_b.append(float(share_b[mask].mean()))
+            continue
+        bin_labels.append(f"{int(round(lo * 100))}%")
+        avg_a.append(float(share_a[mask].mean()))
+        avg_b.append(float(share_b[mask].mean()))
         counts.append(cnt)
 
     avg_a = np.array(avg_a)
@@ -158,7 +132,13 @@ def create_turnout_bar_chart(df,
 
     # ── axes ────────────────────────────────────────────────────────────
     ax.set_xticks(x_pos)
-    ax.set_xticklabels(bin_labels, rotation=-45, ha="left", fontsize=9)
+    # Auto-thin labels when there are many bins
+    if len(bin_labels) > 20:
+        step = max(1, len(bin_labels) // 20)
+        visible_labels = [l if i % step == 0 else "" for i, l in enumerate(bin_labels)]
+        ax.set_xticklabels(visible_labels, rotation=-45, ha="left", fontsize=9)
+    else:
+        ax.set_xticklabels(bin_labels, rotation=-45, ha="left", fontsize=9)
     ax.set_ylim(0, 1)
     ax.yaxis.set_major_formatter(PercentFormatter(1))
     ax.set_xlabel("Voter Turnout (%)", fontsize=14, fontweight="bold")

--- a/tutorials/analysis/scripts/turnout_bar_chart.py
+++ b/tutorials/analysis/scripts/turnout_bar_chart.py
@@ -27,7 +27,7 @@ COLOR_A = "#e63946"          # candidate A bars (red)
 COLOR_B = "#4287f5"          # candidate B bars (blue)
 COLOR_TREND_A = "#9f1239"    # darker red for trend line
 COLOR_TREND_B = "#1e40af"    # darker blue for trend line
-BAR_ALPHA = 0.65
+BAR_ALPHA = 0.85
 
 
 # ── adaptive bin sizing (mirrors React desktop logic) ───────────────────

--- a/tutorials/analysis/scripts/turnout_bar_chart.py
+++ b/tutorials/analysis/scripts/turnout_bar_chart.py
@@ -65,7 +65,9 @@ def create_turnout_bar_chart(df,
                               candidate_b_column,
                               total_column,
                               title,
-                              show_trend: bool = True):
+                              show_trend: bool = True,
+                              bin_pct_override: float = None,
+                              min_precincts: int = 3):
 
     turnout = df["turnout_percent"].values.astype(float)
     share_a = df[f"{candidate_a_column}_share"].values.astype(float)
@@ -73,25 +75,53 @@ def create_turnout_bar_chart(df,
 
     # ── bin precincts by turnout ────────────────────────────────────────
     n = len(turnout)
-    bin_pct = _adaptive_bin_pct(n)
+    bin_pct = bin_pct_override if bin_pct_override is not None else _adaptive_bin_pct(n)
     increment = bin_pct / 100.0
     n_bins = int(np.ceil(1.0 / increment))
+
+    # Find the range of bins that have data, include all bins in that range
+    # (including empty ones) for even spacing
+    first_bin = None
+    last_bin = None
+    for i in range(n_bins):
+        lo = i * increment
+        hi = min((i + 1) * increment, 1.0)
+        mask = (turnout >= lo) & (turnout < hi)
+        if mask.sum() > 0:
+            if first_bin is None:
+                first_bin = i
+            last_bin = i
+
+    if first_bin is None:
+        first_bin, last_bin = 0, 0
+
+    # Trim trailing bins from the right where count < min_precincts
+    # (keeps all bins from first data to last meaningful data)
+    trimmed_last = first_bin
+    for i in range(first_bin, last_bin + 1):
+        lo = i * increment
+        hi = min((i + 1) * increment, 1.0)
+        mask = (turnout >= lo) & (turnout < hi)
+        if mask.sum() >= min_precincts:
+            trimmed_last = i
 
     bin_labels = []
     avg_a = []
     avg_b = []
     counts = []
 
-    for i in range(n_bins):
+    for i in range(first_bin, trimmed_last + 1):
         lo = i * increment
         hi = min((i + 1) * increment, 1.0)
         mask = (turnout >= lo) & (turnout < hi)
         cnt = mask.sum()
-        if cnt == 0:
-            continue
         bin_labels.append(f"{int(round(lo * 100))}%")
-        avg_a.append(float(share_a[mask].mean()))
-        avg_b.append(float(share_b[mask].mean()))
+        if cnt == 0:
+            avg_a.append(0.0)
+            avg_b.append(0.0)
+        else:
+            avg_a.append(float(share_a[mask].mean()))
+            avg_b.append(float(share_b[mask].mean()))
         counts.append(cnt)
 
     avg_a = np.array(avg_a)
@@ -183,13 +213,16 @@ if __name__ == "__main__":
         race_cfg["total_column"],
     )
 
+    chart_cfg = race_cfg["turnout_bar_chart"]
     fig = create_turnout_bar_chart(
         clean_df,
         race_cfg["candidate_a_column"],
         race_cfg["candidate_b_column"],
         race_cfg["total_column"],
-        race_cfg["turnout_bar_chart"]["title"],
+        chart_cfg["title"],
         show_trend=True,
+        bin_pct_override=chart_cfg.get("bin_pct", None),
+        min_precincts=chart_cfg.get("min_precincts", 3),
     )
 
     out_dir = utils.ensure_output_dir()

--- a/tutorials/analysis/scripts/turnout_bar_chart.py
+++ b/tutorials/analysis/scripts/turnout_bar_chart.py
@@ -1,0 +1,199 @@
+"""
+Turnout Bar Chart: average candidate vote share by turnout-percentage bins.
+
+Visual style matches the React/D3 BarChart.tsx component:
+  - X-axis: Voter Turnout (%)   Y-axis: Candidate Vote Share (%)  0-100 %
+  - Grouped side-by-side bars: blue (#4287f5) for candidate B,
+    red (#e63946) for candidate A
+  - 50 % dashed reference line
+  - Optional smoothed trend lines (dark blue / dark red)
+  - Legend at top with square swatches
+"""
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from matplotlib.ticker import PercentFormatter
+import numpy as np
+
+import utils
+import parameters
+
+
+# ── React-matching colours ──────────────────────────────────────────────
+COLOR_A = "#e63946"          # candidate A bars (red)
+COLOR_B = "#4287f5"          # candidate B bars (blue)
+COLOR_TREND_A = "#9f1239"    # darker red for trend line
+COLOR_TREND_B = "#1e40af"    # darker blue for trend line
+BAR_ALPHA = 0.65
+
+
+# ── adaptive bin sizing (mirrors React desktop logic) ───────────────────
+def _adaptive_bin_pct(n: int) -> float:
+    """Return turnout bin size (percentage points) matching React."""
+    if n < 30:
+        return 8
+    elif n < 100:
+        return 6
+    elif n < 300:
+        return 4
+    elif n < 1000:
+        return 2.5
+    elif n < 3000:
+        return 1.5
+    else:
+        return 1
+
+
+# ── running average (matches React windowSize=5) ───────────────────────
+def _running_average(values: np.ndarray, window: int = 5) -> np.ndarray:
+    """Centered running average over *window* elements."""
+    out = np.empty_like(values)
+    half = window // 2
+    for i in range(len(values)):
+        lo = max(0, i - half)
+        hi = min(len(values), i + half + 1)
+        out[i] = values[lo:hi].mean()
+    return out
+
+
+# ── main chart ──────────────────────────────────────────────────────────
+def create_turnout_bar_chart(df,
+                              candidate_a_column,
+                              candidate_b_column,
+                              total_column,
+                              title,
+                              show_trend: bool = True):
+
+    turnout = df["turnout_percent"].values.astype(float)
+    share_a = df[f"{candidate_a_column}_share"].values.astype(float)
+    share_b = df[f"{candidate_b_column}_share"].values.astype(float)
+
+    # ── bin precincts by turnout ────────────────────────────────────────
+    n = len(turnout)
+    bin_pct = _adaptive_bin_pct(n)
+    increment = bin_pct / 100.0
+    n_bins = int(np.ceil(1.0 / increment))
+
+    bin_labels = []
+    avg_a = []
+    avg_b = []
+    counts = []
+
+    for i in range(n_bins):
+        lo = i * increment
+        hi = min((i + 1) * increment, 1.0)
+        mask = (turnout >= lo) & (turnout < hi)
+        cnt = mask.sum()
+        if cnt == 0:
+            continue
+        bin_labels.append(f"{int(round(lo * 100))}%")
+        avg_a.append(float(share_a[mask].mean()))
+        avg_b.append(float(share_b[mask].mean()))
+        counts.append(cnt)
+
+    avg_a = np.array(avg_a)
+    avg_b = np.array(avg_b)
+    x_pos = np.arange(len(bin_labels))
+    bar_width = 0.38
+
+    # ── figure ──────────────────────────────────────────────────────────
+    fig, ax = plt.subplots(figsize=(14, 7), facecolor="white")
+    ax.set_facecolor("white")
+
+    # Grouped bars
+    ax.bar(x_pos - bar_width / 2, avg_b, width=bar_width,
+           color=COLOR_B, alpha=BAR_ALPHA, edgecolor="#333",
+           linewidth=0.8, zorder=2, label=candidate_b_column)
+
+    ax.bar(x_pos + bar_width / 2, avg_a, width=bar_width,
+           color=COLOR_A, alpha=BAR_ALPHA, edgecolor="#333",
+           linewidth=0.8, zorder=2, label=candidate_a_column)
+
+    # ── 50 % dashed reference line ──────────────────────────────────────
+    ax.axhline(y=0.5, color="#888", linewidth=1, linestyle="--", zorder=1)
+    ax.text(-0.6, 0.5, "50%", va="center", ha="right",
+            fontsize=10, color="#888")
+
+    # ── trend lines ─────────────────────────────────────────────────────
+    if show_trend and len(avg_a) >= 3:
+        smooth_a = _running_average(avg_a, window=5)
+        smooth_b = _running_average(avg_b, window=5)
+        ax.plot(x_pos, smooth_b, color=COLOR_TREND_B, linewidth=3.5,
+                marker="o", markersize=4, zorder=4)
+        ax.plot(x_pos, smooth_a, color=COLOR_TREND_A, linewidth=3.5,
+                marker="o", markersize=4, zorder=4)
+
+    # ── axes ────────────────────────────────────────────────────────────
+    ax.set_xticks(x_pos)
+    ax.set_xticklabels(bin_labels, rotation=-45, ha="left", fontsize=9)
+    ax.set_ylim(0, 1)
+    ax.yaxis.set_major_formatter(PercentFormatter(1))
+    ax.set_xlabel("Voter Turnout (%)", fontsize=14, fontweight="bold")
+    ax.set_ylabel("Candidate Vote Share (%)", fontsize=14, fontweight="bold")
+    ax.set_title(title, fontsize=14, fontweight="bold", pad=12)
+
+    ax.tick_params(labelsize=12)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    # Subtle grid
+    ax.grid(axis="y", linestyle="--", linewidth=0.5, alpha=0.3)
+
+    # ── legend ──────────────────────────────────────────────────────────
+    swatch_b = mpatches.Patch(facecolor=COLOR_B, edgecolor="#333",
+                              label=candidate_b_column)
+    swatch_a = mpatches.Patch(facecolor=COLOR_A, edgecolor="#333",
+                              label=candidate_a_column)
+    handles = [swatch_b, swatch_a]
+
+    if show_trend and len(avg_a) >= 3:
+        trend_handle = plt.Line2D([], [], color="#555", linewidth=3,
+                                  marker="o", markersize=4,
+                                  label="Trend Lines")
+        handles.append(trend_handle)
+
+    ax.legend(handles=handles,
+              loc="upper center", bbox_to_anchor=(0.5, 1.0),
+              ncol=len(handles), frameon=False, fontsize=11,
+              handlelength=1.5, handleheight=1.2)
+
+    fig.tight_layout()
+    return fig
+
+
+# ── entry point ─────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    race = utils.choose_race_for_chart(parameters.params,
+                                       chart_key="turnout_bar_chart")
+    if not race:
+        print("No selection made; exiting.")
+        raise SystemExit(0)
+    election_key, race_key, race_cfg = race
+    print(f"\nUsing: {election_key} / {race_key}\n")
+
+    df = utils.load_data_frame(race_cfg["file"])
+    clean_df = utils.get_voter_stats(
+        df,
+        race_cfg["registration_column"],
+        race_cfg["candidate_a_column"],
+        race_cfg["candidate_b_column"],
+        race_cfg["total_column"],
+    )
+
+    fig = create_turnout_bar_chart(
+        clean_df,
+        race_cfg["candidate_a_column"],
+        race_cfg["candidate_b_column"],
+        race_cfg["total_column"],
+        race_cfg["turnout_bar_chart"]["title"],
+        show_trend=True,
+    )
+
+    out_dir = utils.ensure_output_dir()
+    out_path = out_dir / f"{election_key}_{race_key}_turnout_bar_chart.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved → {out_path}")

--- a/tutorials/analysis/scripts/turnout_heatmap.py
+++ b/tutorials/analysis/scripts/turnout_heatmap.py
@@ -1,0 +1,151 @@
+"""
+Turnout Heatmap: 2-D kernel density of precincts in
+  (voter turnout %) × (candidate vote share %) space.
+
+Visual style matches the React/D3 DensityHeatmapByTurnout.tsx component:
+  - X-axis: Voter Turnout (%)   Y-axis: Candidate Vote Share (%)
+  - 2-D Gaussian KDE rendered as filled contours (discrete bands)
+  - Colormap: matplotlib 'turbo' (matches d3.interpolateTurbo)
+  - Candidate-A density shown by default; candidate-B available
+  - Legend on the right with square swatches
+  - Dark-blue (#000091) background inside the chart area
+"""
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import matplotlib.colors as mcolors
+from matplotlib.ticker import PercentFormatter
+import numpy as np
+
+import utils
+import parameters
+
+try:
+    from scipy import stats as sp_stats
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+
+# ── main chart ──────────────────────────────────────────────────────────
+def create_turnout_heatmap(df,
+                            candidate_a_column,
+                            candidate_b_column,
+                            total_column,
+                            title,
+                            grid_size: int = 200,
+                            bandwidth=None):
+    """
+    Parameters
+    ----------
+    grid_size : int
+        Resolution of the KDE evaluation grid (grid_size × grid_size).
+    bandwidth : float or None
+        KDE bandwidth (Scott's rule if None).
+    """
+    if not HAS_SCIPY:
+        raise ImportError(
+            "scipy is required for the turnout heatmap.  "
+            "Install it with:  pip install scipy"
+        )
+
+    turnout = df["turnout_percent"].values.astype(float)
+    share_a = df[f"{candidate_a_column}_share"].values.astype(float)
+    share_b = df[f"{candidate_b_column}_share"].values.astype(float)
+
+    # ── figure ──────────────────────────────────────────────────────────
+    fig, ax = plt.subplots(figsize=(10, 9), facecolor="white")
+
+    # Dark-blue background inside the chart area (matches React #000091)
+    ax.set_facecolor("#000091")
+
+    # ── 2-D KDE for candidate A ────────────────────────────────────────
+    xy_a = np.vstack([turnout, share_a])
+    bw = bandwidth or "scott"
+    kde_a = sp_stats.gaussian_kde(xy_a, bw_method=bw)
+
+    # Evaluation grid (0–1 on both axes)
+    xgrid = np.linspace(0, 1, grid_size)
+    ygrid = np.linspace(0, 1, grid_size)
+    X, Y = np.meshgrid(xgrid, ygrid)
+    positions = np.vstack([X.ravel(), Y.ravel()])
+    Z_a = kde_a(positions).reshape(grid_size, grid_size)
+
+    # ── filled contours (discrete bands matching React d3.contourDensity) ──
+    n_levels = 20   # React default: densityResolution = 20
+    levels = np.linspace(Z_a.min(), Z_a.max(), n_levels + 1)
+    cf = ax.contourf(
+        X, Y, Z_a,
+        levels=levels,
+        cmap="turbo",       # matches d3.interpolateTurbo
+        alpha=0.8,          # matches React opacity: 0.8
+        zorder=1,
+    )
+
+    # ── axes ────────────────────────────────────────────────────────────
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.xaxis.set_major_formatter(PercentFormatter(1))
+    ax.yaxis.set_major_formatter(PercentFormatter(1))
+    ax.set_xlabel("Voter Turnout (%)", fontsize=14, fontweight="bold")
+    ax.set_ylabel("Candidate Vote Share (%)", fontsize=14, fontweight="bold")
+    ax.set_title(title, fontsize=14, fontweight="bold", pad=12)
+
+    ax.tick_params(labelsize=12, colors="#333")
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    # ── legend (square swatches at right) ───────────────────────────────
+    swatch_a = mpatches.Patch(facecolor="#e63946", edgecolor="#333",
+                              label=candidate_a_column)
+    swatch_b = mpatches.Patch(facecolor="#888888", edgecolor="#333",
+                              label=candidate_b_column)
+    ax.legend(handles=[swatch_a, swatch_b],
+              loc="upper right", frameon=True, fontsize=11,
+              facecolor="white", edgecolor="#ccc",
+              handlelength=1.5, handleheight=1.2)
+
+    # ── colorbar ────────────────────────────────────────────────────────
+    cbar = fig.colorbar(cf, ax=ax, shrink=0.65, pad=0.02)
+    cbar.set_label("Precinct Density", fontsize=12)
+    cbar.ax.tick_params(labelsize=10)
+
+    fig.tight_layout()
+    return fig
+
+
+# ── entry point ─────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    race = utils.choose_race_for_chart(parameters.params,
+                                       chart_key="turnout_heatmap")
+    if not race:
+        print("No selection made; exiting.")
+        raise SystemExit(0)
+    election_key, race_key, race_cfg = race
+    print(f"\nUsing: {election_key} / {race_key}\n")
+
+    df = utils.load_data_frame(race_cfg["file"])
+    clean_df = utils.get_voter_stats(
+        df,
+        race_cfg["registration_column"],
+        race_cfg["candidate_a_column"],
+        race_cfg["candidate_b_column"],
+        race_cfg["total_column"],
+    )
+
+    fig = create_turnout_heatmap(
+        clean_df,
+        race_cfg["candidate_a_column"],
+        race_cfg["candidate_b_column"],
+        race_cfg["total_column"],
+        race_cfg["turnout_heatmap"]["title"],
+    )
+
+    out_dir = utils.ensure_output_dir()
+    out_path = out_dir / f"{election_key}_{race_key}_turnout_heatmap.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved → {out_path}")

--- a/tutorials/analysis/scripts/turnout_heatmap.py
+++ b/tutorials/analysis/scripts/turnout_heatmap.py
@@ -36,11 +36,14 @@ def create_turnout_heatmap(df,
                             candidate_b_column,
                             total_column,
                             title,
+                            candidate: str = "a",
                             grid_size: int = 200,
                             bandwidth=None):
     """
     Parameters
     ----------
+    candidate : str
+        Which candidate's density to display: "a" or "b".
     grid_size : int
         Resolution of the KDE evaluation grid (grid_size × grid_size).
     bandwidth : float or None
@@ -62,23 +65,25 @@ def create_turnout_heatmap(df,
     # Dark-blue background inside the chart area (matches React #000091)
     ax.set_facecolor("#000091")
 
-    # ── 2-D KDE for candidate A ────────────────────────────────────────
-    xy_a = np.vstack([turnout, share_a])
+    # ── 2-D KDE for selected candidate ────────────────────────────────
+    active_share = share_a if candidate.lower() == "a" else share_b
+    active_label = candidate_a_column if candidate.lower() == "a" else candidate_b_column
+    xy = np.vstack([turnout, active_share])
     bw = bandwidth or "scott"
-    kde_a = sp_stats.gaussian_kde(xy_a, bw_method=bw)
+    kde = sp_stats.gaussian_kde(xy, bw_method=bw)
 
     # Evaluation grid (0–1 on both axes)
     xgrid = np.linspace(0, 1, grid_size)
     ygrid = np.linspace(0, 1, grid_size)
     X, Y = np.meshgrid(xgrid, ygrid)
     positions = np.vstack([X.ravel(), Y.ravel()])
-    Z_a = kde_a(positions).reshape(grid_size, grid_size)
+    Z = kde(positions).reshape(grid_size, grid_size)
 
     # ── filled contours (discrete bands matching React d3.contourDensity) ──
     n_levels = 20   # React default: densityResolution = 20
-    levels = np.linspace(Z_a.min(), Z_a.max(), n_levels + 1)
+    levels = np.linspace(Z.min(), Z.max(), n_levels + 1)
     cf = ax.contourf(
-        X, Y, Z_a,
+        X, Y, Z,
         levels=levels,
         cmap="turbo",       # matches d3.interpolateTurbo
         alpha=0.8,          # matches React opacity: 0.8
@@ -98,11 +103,17 @@ def create_turnout_heatmap(df,
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
 
-    # ── legend (square swatches at right) ───────────────────────────────
-    swatch_a = mpatches.Patch(facecolor="#e63946", edgecolor="#333",
-                              label=candidate_a_column)
-    swatch_b = mpatches.Patch(facecolor="#888888", edgecolor="#333",
-                              label=candidate_b_column)
+    # ── legend (square swatches at right, active candidate highlighted) ──
+    if candidate.lower() == "a":
+        swatch_a = mpatches.Patch(facecolor="#e63946", edgecolor="#333",
+                                  linewidth=2, label=candidate_a_column)
+        swatch_b = mpatches.Patch(facecolor="#888888", edgecolor="#888",
+                                  label=candidate_b_column)
+    else:
+        swatch_a = mpatches.Patch(facecolor="#888888", edgecolor="#888",
+                                  label=candidate_a_column)
+        swatch_b = mpatches.Patch(facecolor="#4287f5", edgecolor="#333",
+                                  linewidth=2, label=candidate_b_column)
     ax.legend(handles=[swatch_a, swatch_b],
               loc="upper right", frameon=True, fontsize=11,
               facecolor="white", edgecolor="#ccc",
@@ -136,12 +147,14 @@ if __name__ == "__main__":
         race_cfg["total_column"],
     )
 
+    chart_cfg = race_cfg["turnout_heatmap"]
     fig = create_turnout_heatmap(
         clean_df,
         race_cfg["candidate_a_column"],
         race_cfg["candidate_b_column"],
         race_cfg["total_column"],
-        race_cfg["turnout_heatmap"]["title"],
+        chart_cfg["title"],
+        candidate=chart_cfg.get("candidate", "a"),
     )
 
     out_dir = utils.ensure_output_dir()

--- a/tutorials/analysis/scripts/turnout_histogram.py
+++ b/tutorials/analysis/scripts/turnout_histogram.py
@@ -177,7 +177,19 @@ def create_turnout_histogram(df,
                 ax.plot(xs, gauss / gauss.max() * max_bar,
                         color=color, linewidth=3.5, zorder=5)
 
-    # ── axes ────────────────────────────────────────────────────────────
+    # ── axes (add 10% headroom so KDE curves aren't clipped) ───────────
+    y_max = max(hist_a.max(), hist_b.max())
+    # Check if KDE curves extend higher
+    for child in ax.get_children():
+        if hasattr(child, 'get_ydata'):
+            try:
+                ydata = child.get_ydata()
+                if len(ydata) > 0:
+                    y_max = max(y_max, np.nanmax(ydata))
+            except Exception:
+                pass
+    ax.set_ylim(0, y_max * 1.12)
+
     ax.set_xlim(min_t, max_t)
     ax.xaxis.set_major_formatter(PercentFormatter(1))
     ax.yaxis.set_major_formatter(FuncFormatter(lambda v, _: f"{int(v):,}"))

--- a/tutorials/analysis/scripts/turnout_histogram.py
+++ b/tutorials/analysis/scripts/turnout_histogram.py
@@ -1,0 +1,250 @@
+"""
+Turnout Histogram: vote distribution by voter turnout percentage.
+
+Visual style matches the React/D3 TurnoutHistogram.tsx component:
+  - Overlapping semi-transparent histograms (red for candidate A, blue for B)
+  - Overlap region rendered in muted mauve (#B1768C)
+  - Optional best-fit curves (Gaussian KDE) overlaid as smooth lines
+  - Skew values displayed in the legend
+  - X-axis: Voter Turnout (%)   Y-axis: Number of Votes
+  - Legend at top with square colour swatches
+"""
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from matplotlib.ticker import PercentFormatter, FuncFormatter
+import numpy as np
+
+import utils
+import parameters
+
+# Optional – scipy is used for KDE curves and skew calculation
+try:
+    from scipy import stats as sp_stats
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+
+# ── React-matching colours ──────────────────────────────────────────────
+COLOR_A = "#B22222"          # candidate A bars (red / firebrick)
+COLOR_B = "#6495ED"          # candidate B bars (cornflower blue)
+COLOR_OVERLAP = "#B1768C"    # mauve overlap
+COLOR_CURVE_A = "#990000"    # darker red for best-fit curve
+COLOR_CURVE_B = "#003399"    # darker blue for best-fit curve
+BAR_ALPHA = 0.50
+BAR_EDGE = "#000000"
+
+
+# ── Pearson skew (matches React implementation) ────────────────────────
+def _pearson_skew(turnout: np.ndarray, votes: np.ndarray) -> float:
+    """Weighted Pearson skew = 3(mean − median) / σ."""
+    if len(turnout) < 3 or votes.sum() == 0:
+        return 0.0
+    # weight by log-scale of votes to avoid enormous arrays
+    weights = np.maximum(1, np.round(np.log10(np.maximum(votes, 1)) * 2)).astype(int)
+    expanded = np.repeat(turnout, weights)
+    if len(expanded) < 3:
+        return 0.0
+    mean = expanded.mean()
+    median = np.median(np.sort(expanded))
+    std = expanded.std()
+    if std == 0:
+        return 0.0
+    return float(3 * (mean - median) / std)
+
+
+# ── histogram binning (per-candidate vote counts per turnout bin) ──────
+def _bin_votes(turnout: np.ndarray, votes: np.ndarray,
+               bin_edges: np.ndarray) -> np.ndarray:
+    """Sum *votes* that fall into each turnout bin."""
+    counts = np.zeros(len(bin_edges) - 1)
+    for i in range(len(bin_edges) - 1):
+        mask = (turnout >= bin_edges[i]) & (turnout < bin_edges[i + 1])
+        counts[i] = votes[mask].sum()
+    return counts
+
+
+# ── main chart ──────────────────────────────────────────────────────────
+def create_turnout_histogram(df,
+                              candidate_a_column,
+                              candidate_b_column,
+                              total_column,
+                              title,
+                              show_curves: bool = True):
+
+    turnout = df["turnout_percent"].values.astype(float)
+    votes_a = df[candidate_a_column].values.astype(float)
+    votes_b = df[candidate_b_column].values.astype(float)
+
+    # ── adaptive bin sizing (mirrors React logic) ───────────────────────
+    n = len(turnout)
+    if n < 30:
+        bin_pct = 16
+    elif n < 100:
+        bin_pct = 12
+    elif n < 300:
+        bin_pct = 8
+    elif n < 1000:
+        bin_pct = 5
+    elif n < 3000:
+        bin_pct = 3
+    else:
+        bin_pct = 2
+
+    min_t = max(0, turnout.min() - 0.02)
+    max_t = min(1, turnout.max() + 0.02)
+    n_bins = max(10, min(100, int(np.ceil(100 / bin_pct))))
+    bin_edges = np.linspace(min_t, max_t, n_bins + 1)
+    bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
+    bar_width = bin_edges[1] - bin_edges[0]
+
+    hist_a = _bin_votes(turnout, votes_a, bin_edges)
+    hist_b = _bin_votes(turnout, votes_b, bin_edges)
+
+    # ── skew values ─────────────────────────────────────────────────────
+    skew_a = _pearson_skew(turnout, votes_a)
+    skew_b = _pearson_skew(turnout, votes_b)
+
+    # ── figure ──────────────────────────────────────────────────────────
+    fig, ax = plt.subplots(figsize=(12, 7), facecolor="white")
+    ax.set_facecolor("white")
+
+    # Overlap region (drawn first, behind individual bars)
+    overlap = np.minimum(hist_a, hist_b)
+    ax.bar(bin_centers, overlap, width=bar_width * 0.98,
+           color=COLOR_OVERLAP, alpha=0.7, edgecolor=BAR_EDGE,
+           linewidth=0.8, zorder=2, label="_overlap")
+
+    # Candidate B bars (blue)
+    ax.bar(bin_centers, hist_b, width=bar_width * 0.98,
+           color=COLOR_B, alpha=BAR_ALPHA, edgecolor=BAR_EDGE,
+           linewidth=0.8, zorder=1)
+
+    # Candidate A bars (red) — drawn on top so overlap shows through
+    ax.bar(bin_centers, hist_a, width=bar_width * 0.98,
+           color=COLOR_A, alpha=BAR_ALPHA, edgecolor=BAR_EDGE,
+           linewidth=0.8, zorder=1)
+
+    # Re-draw overlap on top so the mauve is clearly visible
+    ax.bar(bin_centers, overlap, width=bar_width * 0.98,
+           color=COLOR_OVERLAP, alpha=0.7, edgecolor=BAR_EDGE,
+           linewidth=0.8, zorder=3)
+
+    # ── best-fit curves (Gaussian KDE) ──────────────────────────────────
+    if show_curves and HAS_SCIPY:
+        xs = np.linspace(min_t, max_t, 300)
+
+        # Create weighted samples for KDE
+        for votes, color, label in [(votes_a, COLOR_CURVE_A, candidate_a_column),
+                                     (votes_b, COLOR_CURVE_B, candidate_b_column)]:
+            # Expand turnout values by vote weight (capped for performance)
+            weights = np.maximum(1, np.round(votes / max(1, votes.mean()) * 10)).astype(int)
+            weights = np.minimum(weights, 200)   # cap per-precinct expansion
+            expanded = np.repeat(turnout, weights)
+            if len(expanded) < 5:
+                continue
+
+            try:
+                kde = sp_stats.gaussian_kde(expanded, bw_method="scott")
+                density = kde(xs)
+                # Scale density so the curve peak aligns with the bar peak
+                max_bar = hist_a.max() if color == COLOR_CURVE_A else hist_b.max()
+                if density.max() > 0:
+                    scaled = density / density.max() * max_bar
+                    ax.plot(xs, scaled, color=color, linewidth=3.5, zorder=5)
+            except Exception:
+                pass   # gracefully skip if KDE fails
+
+    elif show_curves and not HAS_SCIPY:
+        # Fallback: simple Gaussian fit using numpy only
+        for votes, color in [(votes_a, COLOR_CURVE_A), (votes_b, COLOR_CURVE_B)]:
+            weights = np.maximum(1, np.round(votes / max(1, votes.mean()) * 10)).astype(int)
+            weights = np.minimum(weights, 200)
+            expanded = np.repeat(turnout, weights)
+            if len(expanded) < 5:
+                continue
+            mu, sigma = expanded.mean(), expanded.std()
+            if sigma == 0:
+                continue
+            xs = np.linspace(min_t, max_t, 300)
+            gauss = np.exp(-0.5 * ((xs - mu) / sigma) ** 2)
+            max_bar = hist_a.max() if color == COLOR_CURVE_A else hist_b.max()
+            if gauss.max() > 0:
+                ax.plot(xs, gauss / gauss.max() * max_bar,
+                        color=color, linewidth=3.5, zorder=5)
+
+    # ── axes ────────────────────────────────────────────────────────────
+    ax.set_xlim(min_t, max_t)
+    ax.xaxis.set_major_formatter(PercentFormatter(1))
+    ax.yaxis.set_major_formatter(FuncFormatter(lambda v, _: f"{int(v):,}"))
+    ax.set_xlabel("Voter Turnout (%)", fontsize=14, fontweight="bold")
+    ax.set_ylabel("Number of Votes", fontsize=14, fontweight="bold")
+    ax.set_title(title, fontsize=14, fontweight="bold", pad=12)
+
+    ax.tick_params(labelsize=12)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    # Light grid (matches React dashed grid)
+    ax.grid(axis="both", linestyle="--", linewidth=0.5, alpha=0.4)
+
+    # ── legend ──────────────────────────────────────────────────────────
+    swatch_a = mpatches.Patch(facecolor=COLOR_A, edgecolor="#333", alpha=0.8,
+                              label=f"{candidate_a_column} Votes  (Skew = {skew_a:.3f})")
+    swatch_b = mpatches.Patch(facecolor=COLOR_B, edgecolor="#333", alpha=0.8,
+                              label=f"{candidate_b_column} Votes  (Skew = {skew_b:.3f})")
+    swatch_o = mpatches.Patch(facecolor=COLOR_OVERLAP, edgecolor="#333",
+                              alpha=0.8, label="Overlap")
+
+    handles = [swatch_a, swatch_b, swatch_o]
+    if show_curves:
+        curve_handle = plt.Line2D([], [], color="#333", linewidth=3,
+                                  label="Best-Fit Curves")
+        handles.append(curve_handle)
+
+    ax.legend(handles=handles,
+              loc="upper center", bbox_to_anchor=(0.5, 1.0),
+              ncol=len(handles), frameon=False, fontsize=10,
+              handlelength=1.5, handleheight=1.2)
+
+    fig.tight_layout()
+    return fig
+
+
+# ── entry point ─────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    race = utils.choose_race_for_chart(parameters.params,
+                                       chart_key="turnout_histogram")
+    if not race:
+        print("No selection made; exiting.")
+        raise SystemExit(0)
+    election_key, race_key, race_cfg = race
+    print(f"\nUsing: {election_key} / {race_key}\n")
+
+    df = utils.load_data_frame(race_cfg["file"])
+    clean_df = utils.get_voter_stats(
+        df,
+        race_cfg["registration_column"],
+        race_cfg["candidate_a_column"],
+        race_cfg["candidate_b_column"],
+        race_cfg["total_column"],
+    )
+
+    fig = create_turnout_histogram(
+        clean_df,
+        race_cfg["candidate_a_column"],
+        race_cfg["candidate_b_column"],
+        race_cfg["total_column"],
+        race_cfg["turnout_histogram"]["title"],
+        show_curves=True,
+    )
+
+    out_dir = utils.ensure_output_dir()
+    out_path = out_dir / f"{election_key}_{race_key}_turnout_histogram.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved → {out_path}")

--- a/tutorials/analysis/scripts/turnout_scatter_plot.py
+++ b/tutorials/analysis/scripts/turnout_scatter_plot.py
@@ -1,53 +1,146 @@
-import utils
+"""
+Turnout Scatter Plot: Candidate Vote Share (%) vs Voter Turnout (%).
+
+Visual style matches the React/D3 TurnoutScatterPlot.tsx component:
+  - Hollow circles (white fill, colored stroke)
+  - Stroke colour gradient light→dark based on total votes
+  - Dot size scales 0.4× – 2.0× of base radius (3 pt) with total votes
+  - Segmented trend lines (5 % turnout segments, min 5 points per segment)
+  - Legend at top with square colour swatches
+  - Clean white background
+"""
+
 import matplotlib
-import parameters
-matplotlib.use("MacOSX")
+matplotlib.use("Agg")
+
 import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import matplotlib.patches as mpatches
 from matplotlib.ticker import PercentFormatter
+import numpy as np
+
+import utils
+import parameters
 
 
+# ── colour / size helpers (shared logic with scatter_plot.py) ───────────
+def _lerp_color(c1_hex: str, c2_hex: str, t: float) -> str:
+    c1 = np.array(mcolors.hex2color(c1_hex))
+    c2 = np.array(mcolors.hex2color(c2_hex))
+    return mcolors.rgb2hex(c1 + (c2 - c1) * np.clip(t, 0, 1))
+
+
+def _build_color_array(total_votes: np.ndarray, light: str, dark: str) -> list:
+    mn, mx = total_votes.min(), total_votes.max()
+    if mx == mn:
+        return [dark] * len(total_votes)
+    t = (total_votes - mn) / (mx - mn)
+    return [_lerp_color(light, dark, ti) for ti in t]
+
+
+def _build_sizes(total_votes: np.ndarray, base: float = 3.0) -> np.ndarray:
+    mn, mx = total_votes.min(), total_votes.max()
+    if mx == mn:
+        factor = np.ones_like(total_votes) * 1.2
+    else:
+        factor = 0.4 + (total_votes - mn) / (mx - mn) * (2.0 - 0.4)
+    radii = base * factor
+    return np.pi * radii ** 2
+
+
+# ── segmented trend lines (by 5 % turnout buckets) ─────────────────────
+def _segmented_trend_turnout(turnout: np.ndarray, share: np.ndarray,
+                              seg_pct: float = 0.05):
+    """Return (seg_x, seg_y) averages in 5 % turnout segments."""
+    seg_xs, seg_ys = [], []
+    lo = 0.0
+    while lo < 1.0:
+        hi = lo + seg_pct
+        mask = (turnout >= lo) & (turnout < hi)
+        if mask.sum() >= 5:
+            seg_xs.append(float(turnout[mask].mean()))
+            seg_ys.append(float(share[mask].mean()))
+        lo = hi
+    return np.array(seg_xs), np.array(seg_ys)
+
+
+# ── main chart ──────────────────────────────────────────────────────────
 def create_turnout_scatter_plot(df,
-                                candidate_a_column,
-                                candidate_b_column,
-                                title,
-                                x_axis_label,
-                                y_axis_label,
-                                candidate_a_color,
-                                candidate_b_color,
-                                min_dot_size=4,
-                                max_dot_size=40):
+                                 candidate_a_column,
+                                 candidate_b_column,
+                                 total_column,
+                                 title,
+                                 candidate_a_color_unused,
+                                 candidate_b_color_unused):
+
+    turnout = df["turnout_percent"].values.astype(float)
+    total   = df[total_column].values.astype(float)
+    share_a = df[f'{candidate_a_column}_share'].values.astype(float)
+    share_b = df[f'{candidate_b_column}_share'].values.astype(float)
+
+    colors_a = _build_color_array(total, "#ffa6a9", "#63000c")
+    colors_b = _build_color_array(total, "#80b3ff", "#002d75")
+    sizes    = _build_sizes(total, base=3.0)
+
+    fig, ax = plt.subplots(figsize=(12, 7), facecolor="white")
+    ax.set_facecolor("white")
+
+    # Hollow circles
+    ax.scatter(turnout, share_b, s=sizes,
+               facecolors="white", edgecolors=colors_b, linewidths=1.5,
+               zorder=2)
+    ax.scatter(turnout, share_a, s=sizes,
+               facecolors="white", edgecolors=colors_a, linewidths=1.5,
+               zorder=2)
+
+    # Trend lines (5 % turnout segments)
+    tx_b, ty_b = _segmented_trend_turnout(turnout, share_b)
+    tx_a, ty_a = _segmented_trend_turnout(turnout, share_a)
+
+    if len(tx_b) >= 2:
+        ax.plot(tx_b, ty_b, color="#1e40af", linewidth=3, zorder=3)
+        ax.plot(tx_b, ty_b, 'o', color="#1e40af", markersize=5, zorder=4)
+    if len(tx_a) >= 2:
+        ax.plot(tx_a, ty_a, color="#9f1239", linewidth=3, zorder=3)
+        ax.plot(tx_a, ty_a, 'o', color="#9f1239", markersize=5, zorder=4)
+
+    # Axes
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.xaxis.set_major_formatter(PercentFormatter(1))
+    ax.yaxis.set_major_formatter(PercentFormatter(1))
+    ax.set_xlabel("Voter Turnout (%)", fontsize=14, fontweight="bold")
+    ax.set_ylabel("Candidate Vote Share (%)", fontsize=14, fontweight="bold")
+    ax.set_title(title, fontsize=14, fontweight="bold", pad=12)
+
+    ax.tick_params(labelsize=12)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    # Legend
+    swatch_b = mpatches.Patch(facecolor="#4287f5", edgecolor="#333",
+                              label=candidate_b_column)
+    swatch_a = mpatches.Patch(facecolor="#e63946", edgecolor="#333",
+                              label=candidate_a_column)
+    trend_b = plt.Line2D([], [], color="#1e40af", linewidth=3,
+                         marker='o', markersize=5,
+                         label=f"{candidate_b_column} Trend")
+    trend_a = plt.Line2D([], [], color="#9f1239", linewidth=3,
+                         marker='o', markersize=5,
+                         label=f"{candidate_a_column} Trend")
+    ax.legend(handles=[swatch_b, swatch_a, trend_b, trend_a],
+              loc="upper center", bbox_to_anchor=(0.5, 1.0),
+              ncol=4, frameon=False, fontsize=11,
+              handlelength=1.5, handleheight=1.2)
+
+    fig.tight_layout()
+    return fig
 
 
-    plt.scatter(df['turnout_percent'],
-                df[f'{candidate_a_column}_share'],
-                alpha=0.3,
-                s=utils.get_dot_size(min_dot_size, max_dot_size, df[candidate_a_column]),
-                color=candidate_a_color,
-                edgecolors=candidate_a_color,
-                label=candidate_a_column)
-
-    plt.scatter(df['turnout_percent'],
-                df[f'{candidate_b_column}_share'],
-                s=utils.get_dot_size(min_dot_size, max_dot_size, df[candidate_b_column]),
-                alpha=0.3,
-                edgecolors=candidate_b_color,
-                color=candidate_b_color,
-                label=candidate_b_column)
-
-    plt.gca().xaxis.set_major_formatter(PercentFormatter(1))
-    plt.gca().yaxis.set_major_formatter(PercentFormatter(1))
-
-    # add labels and title
-    plt.xlabel(x_axis_label)
-    plt.ylabel(y_axis_label)
-    plt.title(title)
-
-    # show it
-    plt.show()
-
-
+# ── entry point ─────────────────────────────────────────────────────────
 if __name__ == "__main__":
-    race = utils.choose_race_for_chart(parameters.params, chart_key="turnout_scatter_plot")
+    race = utils.choose_race_for_chart(parameters.params,
+                                       chart_key="turnout_scatter_plot")
     if not race:
         print("No selection made; exiting.")
         raise SystemExit(0)
@@ -55,21 +148,26 @@ if __name__ == "__main__":
     print(f"\nUsing: {election_key} / {race_key}\n")
 
     df = utils.load_data_frame(race_cfg["file"])
-
     clean_df = utils.get_voter_stats(
         df,
         race_cfg["registration_column"],
         race_cfg["candidate_a_column"],
         race_cfg["candidate_b_column"],
-        race_cfg["total_column"]
+        race_cfg["total_column"],
     )
 
-    create_turnout_scatter_plot(
+    fig = create_turnout_scatter_plot(
         clean_df,
-        race_cfg['candidate_a_column'],
-        race_cfg['candidate_b_column'],
-        race_cfg["turnout_scatter_plot"]['title'],
-        race_cfg["turnout_scatter_plot"]['x_axis_label'],
-        race_cfg["turnout_scatter_plot"]['y_axis_label'],
-        race_cfg['candidate_a_color'],
-        race_cfg['candidate_b_color'])
+        race_cfg["candidate_a_column"],
+        race_cfg["candidate_b_column"],
+        race_cfg["total_column"],
+        race_cfg["turnout_scatter_plot"]["title"],
+        race_cfg["candidate_a_color"],
+        race_cfg["candidate_b_color"],
+    )
+
+    out_dir = utils.ensure_output_dir()
+    out_path = out_dir / f"{election_key}_{race_key}_turnout_scatter.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved → {out_path}")

--- a/tutorials/analysis/scripts/utils.py
+++ b/tutorials/analysis/scripts/utils.py
@@ -5,6 +5,18 @@ from typing import Dict, List, Tuple, Any, Optional
 
 ERROR_TOKENS = {"", "#DIV/0!", "#N/A", "#VALUE!", "#REF!", "#NUM!", "#NAME?", "#NULL!"}
 
+
+def _common_suffix(a: str, b: str) -> Optional[str]:
+    """Return the longest common suffix of two strings (at least 3 chars)."""
+    min_len = min(len(a), len(b))
+    suffix = ""
+    for i in range(1, min_len + 1):
+        if a[-i] == b[-i]:
+            suffix = a[-i:] if i == 1 else a[-i:]
+        else:
+            break
+    return suffix if len(suffix) >= 3 else None
+
 # Small-precinct filtering (disable by setting to None)
 MIN_REGISTERED_VOTERS = 100
 MIN_TOTAL_VOTES = 50
@@ -71,20 +83,32 @@ def get_voter_stats(df, registration_column, candidate_a_column, candidate_b_col
     #   candidate_x_pct = candidate_x_votes / total_votes
     # where total_votes = sum of ALL candidates for that election type.
     #
-    # If `total_column` accurately represents the total for the election type
-    # being analysed, use it directly.  Otherwise (e.g. PA CSV where
-    # total_votes_cast spans ALL voting methods while candidate columns are
-    # Election Day only), fall back to (A + B) as the best available proxy.
+    # If total_column accurately represents the total for the election type,
+    # use it directly.  Otherwise (e.g. PA CSV where total_votes_cast spans
+    # ALL voting methods while candidate columns are Election Day only),
+    # detect the common suffix and sum ALL matching columns.
     two_party = clean[candidate_a_column] + clean[candidate_b_column]
     denom = clean[total_column].copy()
 
     # Detect mismatch: if total >> A+B in most rows, total likely includes
-    # other voting methods → use two-party total instead.
+    # other voting methods.
     ratio = (two_party / denom).median()
     if ratio < 0.75:
-        # total_column includes votes from other methods/types;
-        # fall back to (A + B) for both turnout and share.
-        denom = two_party
+        # Try to find a common suffix (e.g. "- Election Day") and sum ALL
+        # columns in the original DataFrame that share it.
+        suffix = _common_suffix(candidate_a_column, candidate_b_column)
+        if suffix:
+            matching_cols = [c for c in df.columns if c.endswith(suffix)]
+            if len(matching_cols) > 2:
+                all_type_total = sum(
+                    clean_num(df[c]).reindex(clean.index).fillna(0)
+                    for c in matching_cols
+                )
+                denom = all_type_total
+            else:
+                denom = two_party
+        else:
+            denom = two_party
 
     denom = denom.replace(0, np.nan)
 

--- a/tutorials/analysis/scripts/utils.py
+++ b/tutorials/analysis/scripts/utils.py
@@ -66,10 +66,19 @@ def get_voter_stats(df, registration_column, candidate_a_column, candidate_b_col
     # drop rows with bad/zero totals or registrations
     clean = clean[(clean[registration_column] > 0) & (clean[total_column] > 0)]
 
-    clean['turnout_percent'] = tot / reg
+    # Use the sum of the two candidates as the base for vote share and
+    # turnout.  The `total_column` may include other candidates or voting
+    # methods (e.g. PA data has Election Day candidates but total_votes_cast
+    # across *all* methods), so (A + B) is a safer denominator that matches
+    # the React/D3 dashboard behaviour.
+    two_party_total = clean[candidate_a_column] + clean[candidate_b_column]
+    # Guard against division by zero
+    two_party_total = two_party_total.replace(0, np.nan)
 
-    clean[f"{candidate_a_column}_share"] = clean[candidate_a_column] / tot
-    clean[f"{candidate_b_column}_share"] = clean[candidate_b_column] / tot
+    clean['turnout_percent'] = two_party_total / reg
+
+    clean[f"{candidate_a_column}_share"] = clean[candidate_a_column] / two_party_total
+    clean[f"{candidate_b_column}_share"] = clean[candidate_b_column] / two_party_total
 
     # remove div-by-zero/NaN
     clean = clean.replace([np.inf, -np.inf], np.nan).dropna(

--- a/tutorials/analysis/scripts/utils.py
+++ b/tutorials/analysis/scripts/utils.py
@@ -66,19 +66,32 @@ def get_voter_stats(df, registration_column, candidate_a_column, candidate_b_col
     # drop rows with bad/zero totals or registrations
     clean = clean[(clean[registration_column] > 0) & (clean[total_column] > 0)]
 
-    # Use the sum of the two candidates as the base for vote share and
-    # turnout.  The `total_column` may include other candidates or voting
-    # methods (e.g. PA data has Election Day candidates but total_votes_cast
-    # across *all* methods), so (A + B) is a safer denominator that matches
-    # the React/D3 dashboard behaviour.
-    two_party_total = clean[candidate_a_column] + clean[candidate_b_column]
-    # Guard against division by zero
-    two_party_total = two_party_total.replace(0, np.nan)
+    # The dashboard computes:
+    #   turnout_pct     = total_votes / registered_voters
+    #   candidate_x_pct = candidate_x_votes / total_votes
+    # where total_votes = sum of ALL candidates for that election type.
+    #
+    # If `total_column` accurately represents the total for the election type
+    # being analysed, use it directly.  Otherwise (e.g. PA CSV where
+    # total_votes_cast spans ALL voting methods while candidate columns are
+    # Election Day only), fall back to (A + B) as the best available proxy.
+    two_party = clean[candidate_a_column] + clean[candidate_b_column]
+    denom = clean[total_column].copy()
 
-    clean['turnout_percent'] = two_party_total / reg
+    # Detect mismatch: if total >> A+B in most rows, total likely includes
+    # other voting methods → use two-party total instead.
+    ratio = (two_party / denom).median()
+    if ratio < 0.75:
+        # total_column includes votes from other methods/types;
+        # fall back to (A + B) for both turnout and share.
+        denom = two_party
 
-    clean[f"{candidate_a_column}_share"] = clean[candidate_a_column] / two_party_total
-    clean[f"{candidate_b_column}_share"] = clean[candidate_b_column] / two_party_total
+    denom = denom.replace(0, np.nan)
+
+    clean['turnout_percent'] = denom / reg
+
+    clean[f"{candidate_a_column}_share"] = clean[candidate_a_column] / denom
+    clean[f"{candidate_b_column}_share"] = clean[candidate_b_column] / denom
 
     # remove div-by-zero/NaN
     clean = clean.replace([np.inf, -np.inf], np.nan).dropna(

--- a/tutorials/analysis/scripts/utils.py
+++ b/tutorials/analysis/scripts/utils.py
@@ -57,6 +57,12 @@ def get_voter_stats(df, registration_column, candidate_a_column, candidate_b_col
         candidate_b_column: b,
     })
 
+    # Preserve precinct column if present
+    for col in ("precinct", "Precinct", "PRECINCT"):
+        if col in df.columns:
+            clean["precinct"] = df[col].values[:len(clean)]
+            break
+
     # drop rows with bad/zero totals or registrations
     clean = clean[(clean[registration_column] > 0) & (clean[total_column] > 0)]
 
@@ -70,6 +76,13 @@ def get_voter_stats(df, registration_column, candidate_a_column, candidate_b_col
         subset=[f"{candidate_a_column}_share", f"{candidate_b_column}_share"]
     )
     return clean
+
+
+def ensure_output_dir():
+    """Create the output directory if it doesn't exist."""
+    output_dir = Path(__file__).resolve().parent.parent / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
 
 
 def find_races_with_chart(params: Dict[str, Any], chart_key: str) -> List[Tuple[str, str, Dict[str, Any]]]:
@@ -109,9 +122,8 @@ def prompt_user_to_choose(races: List[Tuple[str, str, Dict[str, Any]]], chart_ke
                 return races[idx - 1]
         print(f"Please enter a number between 1 and {len(races)}.")
 
-# Example glue code for your script:
 
-def choose_race_for_chart(params: Dict[str, Any], chart_key: str, prefer_election: str | None = None):
+def choose_race_for_chart(params: Dict[str, Any], chart_key: str, prefer_election: Optional[str] = None):
     # Optionally filter by a specific election if you want:
     subset = params if not prefer_election else {prefer_election: params.get(prefer_election, {})}
     races = find_races_with_chart(subset, chart_key)

--- a/tutorials/analysis/scripts/vote_share_histogram.py
+++ b/tutorials/analysis/scripts/vote_share_histogram.py
@@ -104,16 +104,23 @@ def create_vote_share_histogram(df,
     fig, ax = plt.subplots(figsize=(12, 7), facecolor="white")
     ax.set_facecolor("white")
 
-    # React approach: draw both bar sets at opacity 0.5, natural blend
+    # Draw bars with explicit overlap region (same approach as turnout_histogram)
+    overlap = np.minimum(hist_a, hist_b)
+
     # Candidate B bars (blue) — drawn first (behind)
     ax.bar(bin_centers, hist_b, width=bar_width * 0.98,
            color=COLOR_B, alpha=BAR_ALPHA, edgecolor=BAR_EDGE,
            linewidth=0.8, zorder=1)
 
-    # Candidate A bars (red) — drawn on top, alpha creates natural overlap
+    # Candidate A bars (red)
     ax.bar(bin_centers, hist_a, width=bar_width * 0.98,
            color=COLOR_A, alpha=BAR_ALPHA, edgecolor=BAR_EDGE,
            linewidth=0.8, zorder=2)
+
+    # Explicit overlap region (mauve) drawn on top for clarity
+    ax.bar(bin_centers, overlap, width=bar_width * 0.98,
+           color=COLOR_OVERLAP, alpha=0.7, edgecolor=BAR_EDGE,
+           linewidth=0.8, zorder=3)
 
     # ── best-fit curves (Gaussian KDE on vote share) ────────────────────
     if show_curves and HAS_SCIPY:

--- a/tutorials/analysis/scripts/vote_share_histogram.py
+++ b/tutorials/analysis/scripts/vote_share_histogram.py
@@ -1,0 +1,224 @@
+"""
+Vote Share Histogram: precinct count by candidate vote share percentage.
+
+Visual style matches the React/D3 VoteCountHistogram.tsx component:
+  - X-axis: Candidate Vote Share (%)  Y-axis: Number of Precincts
+  - Overlapping semi-transparent bars (red for candidate A, blue for B)
+  - Overlap region rendered in muted mauve (#B1768C)
+  - Optional best-fit curves (Gaussian KDE) overlaid as smooth lines
+  - Skew values displayed in the legend
+  - Legend at top with square colour swatches
+"""
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from matplotlib.ticker import PercentFormatter
+import numpy as np
+
+import utils
+import parameters
+
+# Optional – scipy is used for KDE curves and skew calculation
+try:
+    from scipy import stats as sp_stats
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+
+# ── React-matching colours ──────────────────────────────────────────────
+COLOR_A = "#B22222"          # candidate A bars (firebrick red)
+COLOR_B = "#6495ED"          # candidate B bars (cornflower blue)
+COLOR_OVERLAP = "#B1768C"    # mauve overlap
+COLOR_CURVE_A = "#990000"    # darker red for best-fit curve
+COLOR_CURVE_B = "#003399"    # darker blue for best-fit curve
+BAR_ALPHA = 0.50
+BAR_EDGE = "#000000"
+
+
+# ── Pearson skew ────────────────────────────────────────────────────────
+def _pearson_skew(values: np.ndarray) -> float:
+    """Pearson skew = 3(mean − median) / σ  on raw vote-share values."""
+    if len(values) < 3:
+        return 0.0
+    mean = values.mean()
+    median = float(np.median(np.sort(values)))
+    std = values.std()
+    if std == 0:
+        return 0.0
+    return float(3 * (mean - median) / std)
+
+
+# ── adaptive bin count (mirrors React logic) ────────────────────────────
+def _adaptive_bin_pct(n: int) -> float:
+    """Return bin-size percentage matching the React desktop logic."""
+    if n < 30:
+        return 8
+    elif n < 100:
+        return 6
+    elif n < 300:
+        return 4
+    elif n < 1000:
+        return 2.5
+    elif n < 3000:
+        return 1.5
+    else:
+        return 1
+
+
+# ── main chart ──────────────────────────────────────────────────────────
+def create_vote_share_histogram(df,
+                                 candidate_a_column,
+                                 candidate_b_column,
+                                 total_column,
+                                 title,
+                                 show_curves: bool = True):
+
+    share_a = df[f"{candidate_a_column}_share"].values.astype(float)
+    share_b = df[f"{candidate_b_column}_share"].values.astype(float)
+
+    # ── adaptive bin sizing ─────────────────────────────────────────────
+    n = len(share_a)
+    bin_pct = _adaptive_bin_pct(n)
+    n_bins = max(10, min(100, int(np.ceil(100 / bin_pct))))
+
+    # Fixed 0-100% range to match React dashboard
+    min_share = 0.0
+    max_share = 1.0
+    bin_edges = np.linspace(min_share, max_share, n_bins + 1)
+    bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
+    bar_width = bin_edges[1] - bin_edges[0]
+
+    # Count precincts in each bin
+    hist_a = np.histogram(share_a, bins=bin_edges)[0].astype(float)
+    hist_b = np.histogram(share_b, bins=bin_edges)[0].astype(float)
+
+    # ── skew values ─────────────────────────────────────────────────────
+    skew_a = _pearson_skew(share_a)
+    skew_b = _pearson_skew(share_b)
+
+    # ── figure ──────────────────────────────────────────────────────────
+    fig, ax = plt.subplots(figsize=(12, 7), facecolor="white")
+    ax.set_facecolor("white")
+
+    # React approach: draw both bar sets at opacity 0.5, natural blend
+    # Candidate B bars (blue) — drawn first (behind)
+    ax.bar(bin_centers, hist_b, width=bar_width * 0.98,
+           color=COLOR_B, alpha=BAR_ALPHA, edgecolor=BAR_EDGE,
+           linewidth=0.8, zorder=1)
+
+    # Candidate A bars (red) — drawn on top, alpha creates natural overlap
+    ax.bar(bin_centers, hist_a, width=bar_width * 0.98,
+           color=COLOR_A, alpha=BAR_ALPHA, edgecolor=BAR_EDGE,
+           linewidth=0.8, zorder=2)
+
+    # ── best-fit curves (Gaussian KDE on vote share) ────────────────────
+    if show_curves and HAS_SCIPY:
+        xs = np.linspace(min_share, max_share, 300)
+
+        for shares, hist, color in [
+            (share_a, hist_a, COLOR_CURVE_A),
+            (share_b, hist_b, COLOR_CURVE_B),
+        ]:
+            if len(shares) < 5:
+                continue
+            try:
+                kde = sp_stats.gaussian_kde(shares, bw_method="scott")
+                density = kde(xs)
+                max_bar = hist.max()
+                if density.max() > 0:
+                    scaled = density / density.max() * max_bar
+                    ax.plot(xs, scaled, color=color, linewidth=3.5, zorder=5)
+            except Exception:
+                pass
+
+    elif show_curves and not HAS_SCIPY:
+        xs = np.linspace(min_share, max_share, 300)
+        for shares, hist, color in [
+            (share_a, hist_a, COLOR_CURVE_A),
+            (share_b, hist_b, COLOR_CURVE_B),
+        ]:
+            if len(shares) < 5:
+                continue
+            mu, sigma = shares.mean(), shares.std()
+            if sigma == 0:
+                continue
+            gauss = np.exp(-0.5 * ((xs - mu) / sigma) ** 2)
+            max_bar = hist.max()
+            if gauss.max() > 0:
+                ax.plot(xs, gauss / gauss.max() * max_bar,
+                        color=color, linewidth=3.5, zorder=5)
+
+    # ── axes ────────────────────────────────────────────────────────────
+    ax.set_xlim(0, 1)
+    ax.xaxis.set_major_formatter(PercentFormatter(1))
+    ax.set_xlabel("Candidate Vote Share (%)", fontsize=14, fontweight="bold")
+    ax.set_ylabel("Number of Precincts", fontsize=14, fontweight="bold")
+    ax.set_title(title, fontsize=14, fontweight="bold", pad=12)
+
+    ax.tick_params(labelsize=12)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    # Light grid (matches React dashed grid)
+    ax.grid(axis="both", linestyle="--", linewidth=0.5, alpha=0.4)
+
+    # ── legend ──────────────────────────────────────────────────────────
+    swatch_a = mpatches.Patch(facecolor=COLOR_A, edgecolor="#333", alpha=0.8,
+                              label=f"{candidate_a_column}  (Skew = {skew_a:.3f})")
+    swatch_b = mpatches.Patch(facecolor=COLOR_B, edgecolor="#333", alpha=0.8,
+                              label=f"{candidate_b_column}  (Skew = {skew_b:.3f})")
+    swatch_o = mpatches.Patch(facecolor=COLOR_OVERLAP, edgecolor="#333",
+                              alpha=0.8, label="Overlap")
+
+    handles = [swatch_a, swatch_b, swatch_o]
+    if show_curves:
+        curve_handle = plt.Line2D([], [], color="#333", linewidth=3,
+                                  label="Best-Fit Curves")
+        handles.append(curve_handle)
+
+    ax.legend(handles=handles,
+              loc="upper center", bbox_to_anchor=(0.5, 1.0),
+              ncol=len(handles), frameon=False, fontsize=10,
+              handlelength=1.5, handleheight=1.2)
+
+    fig.tight_layout()
+    return fig
+
+
+# ── entry point ─────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    race = utils.choose_race_for_chart(parameters.params,
+                                       chart_key="vote_share_histogram")
+    if not race:
+        print("No selection made; exiting.")
+        raise SystemExit(0)
+    election_key, race_key, race_cfg = race
+    print(f"\nUsing: {election_key} / {race_key}\n")
+
+    df = utils.load_data_frame(race_cfg["file"])
+    clean_df = utils.get_voter_stats(
+        df,
+        race_cfg["registration_column"],
+        race_cfg["candidate_a_column"],
+        race_cfg["candidate_b_column"],
+        race_cfg["total_column"],
+    )
+
+    fig = create_vote_share_histogram(
+        clean_df,
+        race_cfg["candidate_a_column"],
+        race_cfg["candidate_b_column"],
+        race_cfg["total_column"],
+        race_cfg["vote_share_histogram"]["title"],
+        show_curves=True,
+    )
+
+    out_dir = utils.ensure_output_dir()
+    out_path = out_dir / f"{election_key}_{race_key}_vote_share_histogram.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+    print(f"Saved → {out_path}")


### PR DESCRIPTION
## Summary

Adds 4 new Python chart scripts that match the React/D3 dashboard visualizations, plus style improvements to the 2 existing scatter plots.

## New Charts

| Script | Description | Dashboard Component |
|--------|-------------|--------------------|
| `turnout_histogram.py` | Overlapping turnout histograms with KDE curves and skew values | TurnoutHistogram |
| `vote_share_histogram.py` | Precinct count by candidate vote share % | VoteShareHistogram |
| `turnout_heatmap.py` | 2D kernel density heatmap (turbo colormap, contour bands, #000091 bg) | DensityHeatmapByTurnout |
| `turnout_bar_chart.py` | Grouped bar chart sorted by turnout % | TurnoutBarChart |

## Updated Charts

- **scatter_plot.py** — Hollow circles with color gradients, thicker trend lines (linewidth 5)
- **turnout_scatter_plot.py** — Same style updates

## Infrastructure

- **parameters.py** — Chart configs for all 6 types across 3 sample races (NC Wake President, NC Wake AG, PA Allegheny President)
- **utils.py** — New helper for interactive race/chart selection
- **requirements.txt** — Added `scipy` dependency
- **README.md** — Documented all scripts with usage
- **.gitignore** — Excludes `__pycache__/` and `output/`

## Usage

```bash
cd tutorials/analysis/scripts
pip install -r requirements.txt
python turnout_heatmap.py   # prompts for race selection, saves PNG to ../output/
```

All scripts use the shared `parameters.py` config and `utils.py` helpers. Colors match the dashboard: Trump=#e63946, Harris=#4287f5.